### PR TITLE
Update the Copy command

### DIFF
--- a/goals/java/1-setup.md
+++ b/goals/java/1-setup.md
@@ -25,7 +25,7 @@ cd AI-Assisted-Coding
 
 # Copy all framework files to your project's root directory
 # Replace 'your-project-path' with the actual path to your project
-Copy-Item -Path ".\*" -Destination "C:\path\to\your-project\" -Recurse -Force
+robocopy "." "C:\path\to\your-project\" /E /XD ".git"
 ```
 
 ### Step 2 (optional): Change the MCP Configuration


### PR DESCRIPTION
This pull request updates the setup instructions in the `goals/java/1-setup.md` file to use a more robust file copying command. 

Documentation improvement:

* Replaced the `Copy-Item` command with `robocopy` in the setup instructions to provide better handling of file copying, including recursive copying and exclusion of the `.git` directory. (`[goals/java/1-setup.mdL28-R28](diffhunk://#diff-68c236ef14285360a6598a3747ca782d0eb01c8603ce71410116cb41c9cd9602L28-R28)`)Updated copy command for avoid. GIT folder